### PR TITLE
Fix importing range for python3

### DIFF
--- a/nflgame/compat.py
+++ b/nflgame/compat.py
@@ -64,6 +64,8 @@ if IS_PY3:
     # Constants
     binary_type = bytes
     text_type = str
+    range = range
+    input = input
 
     # Dict iter functions
     def iteritems(obj, **kwargs):


### PR DESCRIPTION
Importing nflgame in python3 threw an error due to line 10 in update_sched.py:

``` python
from nflgame.compat import OrderedDict, range, urllib
```
